### PR TITLE
Add an environment variable to remove all handlers of nose logger

### DIFF
--- a/nose/config.py
+++ b/nose/config.py
@@ -192,6 +192,7 @@ class Config(object):
         self.debug = env.get('NOSE_DEBUG')
         self.debugLog = env.get('NOSE_DEBUG_LOG')
         self.logPropagate = bool(env.get('NOSE_LOG_PROPAGATE', False))
+        self.logNoLogHandlers = bool(env.get('NOSE_NO_LOG_HANDLERS', False))
         self.exclude = None
         self.getTestCaseNamesCompat = False
         self.includeExe = env.get('NOSE_INCLUDE_EXE',
@@ -388,6 +389,9 @@ class Config(object):
                     found = True
         if not found:
             logger.addHandler(handler)
+
+        if self.logNoLogHandlers:
+            logger.handlers = []
 
         # default level
         lvl = logging.WARNING


### PR DESCRIPTION
If the log can propagate to upper level, there is no need to add extra logging handlers in nose level.